### PR TITLE
Feature: add `AUTO_PKG` instruction

### DIFF
--- a/dep_tree.go
+++ b/dep_tree.go
@@ -28,8 +28,9 @@ type DependencyTree struct {
 
 // package metadata used in sum file.
 type PackageMeta struct {
-	PackageName string `yaml:"pkg"`    // package name (usually it is a path)
-	TargetName  string `yaml:"target"` // cmake package name
+	PackageName string   `yaml:"pkg"`    // package name (usually it is a path)
+	TargetName  string   `yaml:"target"` // cmake package name
+	Features    []string `yaml:"features"`
 	//	SrcPath      string   `yaml:"-"`
 	Version      string   `yaml:"version"`
 	Builder      []string `yaml:"builder"`        // outer builder (lib used by others, specified by others pkg)

--- a/example/pkg.yaml
+++ b/example/pkg.yaml
@@ -34,6 +34,8 @@ dependencies:
         - CP toml.hpp {{.INCLUDE}}/toml.hpp
 
 build:
+  fallback:
+    - RUN {{.CACHE}} cmake {{.SRC_DIR}} -DCMAKE_INSTALL_PREFIX={{.PKG_DIR}}; make -j {{.CORES}}; make install
   linux:
     - RUN {{.CACHE}} cmake {{.SRC_DIR}} -DCMAKE_INSTALL_PREFIX={{.PKG_DIR}}; make -j {{.CORES}}; make install
   darwin:

--- a/instructions.go
+++ b/instructions.go
@@ -1,0 +1,7 @@
+package pkg
+
+// this shows the supported instructions in pkg
+const (
+	InsCmake   = "CMAKE" // run cmake configuration and build,install
+	InsAutoPkg = "AUTO_PKG"
+)

--- a/pkg/fetch/fetch.go
+++ b/pkg/fetch/fetch.go
@@ -13,7 +13,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
 )
 
 var fetchCommand = &cmds.Command{
@@ -158,8 +157,10 @@ func (f *fetch) fetchSubDependency(pkgPath string, pkgVendorSrcPath string, pkgL
 
 			// add to build this package.
 			// only all its dependency packages are downloaded, can this package be built.
-			if build, ok := pkgYaml.Build[runtime.GOOS]; ok {
-				depTree.Context.SelfBuild = build[:]
+			if builder, err := pkgYaml.FindBuilder(); err != nil {
+				return err
+			} else {
+				depTree.Context.SelfBuild = builder
 			}
 			depTree.Context.SelfCMakeLib = pkgYaml.CMakeLib // add cmake include script for this lib
 			depTree.IsPkgPackage = true

--- a/pkg/fetch/fetch.go
+++ b/pkg/fetch/fetch.go
@@ -157,12 +157,14 @@ func (f *fetch) fetchSubDependency(pkgPath string, pkgVendorSrcPath string, pkgL
 
 			// add to build this package.
 			// only all its dependency packages are downloaded, can this package be built.
-			if builder, err := pkgYaml.FindBuilder(); err != nil {
-				return err
-			} else {
+			builder := pkgYaml.FindBuilder()
+			// overwrite the default builder command and cmake lib,
+			// if they are specified here.
+			if !(builder == nil || len(builder) == 0) || pkgYaml.CMakeLib != "" {
 				depTree.Context.SelfBuild = builder
+				depTree.Context.SelfCMakeLib = pkgYaml.CMakeLib // add cmake include script for this lib
 			}
-			depTree.Context.SelfCMakeLib = pkgYaml.CMakeLib // add cmake include script for this lib
+
 			depTree.IsPkgPackage = true
 			if depTree.Dependencies == nil {
 				depTree.Dependencies = make([]*pkg.DependencyTree, 0)

--- a/pkg/fetch/fetcher.go
+++ b/pkg/fetch/fetcher.go
@@ -20,6 +20,7 @@ type YamlFilesPkgFetcher pkg.YamlFilesPackage
 func (git *YamlGitPkgFetcher) setPackageMeta(pkgPath string, meta *pkg.PackageMeta) error {
 	meta.Version = git.Version
 	meta.TargetName = git.Target
+	meta.Features = git.Features
 	meta.CMakeLib = git.CMakeLib
 	meta.Builder = git.Build[:]
 	if meta.CMakeLib == "" && len(meta.Builder) == 0 {

--- a/pkg/fetch/fetcher.go
+++ b/pkg/fetch/fetcher.go
@@ -22,6 +22,15 @@ func (git *YamlGitPkgFetcher) setPackageMeta(pkgPath string, meta *pkg.PackageMe
 	meta.TargetName = git.Target
 	meta.CMakeLib = git.CMakeLib
 	meta.Builder = git.Build[:]
+	if meta.CMakeLib == "" && len(meta.Builder) == 0 {
+		// if user specified cmake lib and build commands are not set,
+		// we set self cmake lib and self build commands.
+		// Note: this self cmake lib and self build commands can be overwrite
+		// by package specified self cmake lib and self build commands.
+		meta.SelfCMakeLib = pkg.InsAutoPkg
+		bs := []string{pkg.InsAutoPkg}
+		meta.SelfBuild = bs[:]
+	}
 
 	// parse package path(name), target and version from key and gitPkg
 	if err := meta.SetPackageName(pkgPath); err != nil {

--- a/pkg/install/command.go
+++ b/pkg/install/command.go
@@ -55,7 +55,7 @@ func RunIns(pkgHome, pkgName, srcPath, ins string, verbose bool) error {
 		if err := involveShell(pkgHome, workDir, triple.Third, verbose); err != nil {
 			return err
 		}
-	case "CMAKE": // run cmake commands, format CMAKE {config args} {build args}
+	case pkg.InsCmake: // run cmake commands, format CMAKE {config args} {build args}
 		packageCacheDir := pkg.GetCachePath(pkgHome, pkgName)
 		// remove old work dir files.
 		if _, err := os.Stat(packageCacheDir); err != nil {
@@ -154,7 +154,7 @@ func WriteIns(w *bufio.Writer, pkgHome, pkgName, packageSrcPath, ins string) err
 		}
 	}
 
-	if triple.First == "CMAKE" {
+	if triple.First == pkg.InsCmake {
 		var configCmd = fmt.Sprintf("cmake -S \"%s\" -B \"%s\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\"%s\" %s",
 			packageSrcPath, pkg.GetCachePath(pkgHome, pkgName), pkg.GetPackagePkgPath(pkgHome, pkgName), triple.Second)
 		var buildCmd = fmt.Sprintf("cmake --build \"%s\" --target install %s",

--- a/pkg/install/command.go
+++ b/pkg/install/command.go
@@ -158,7 +158,7 @@ func WriteIns(w *bufio.Writer, pkgHome, pkgName, packageSrcPath, ins string) err
 		var configCmd = fmt.Sprintf("cmake -S \"%s\" -B \"%s\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\"%s\" %s",
 			packageSrcPath, pkg.GetCachePath(pkgHome, pkgName), pkg.GetPackagePkgPath(pkgHome, pkgName), triple.Second)
 		var buildCmd = fmt.Sprintf("cmake --build \"%s\" --target install %s",
-			pkg.GetCachePath(pkgHome, pkgName), triple.Second)
+			pkg.GetCachePath(pkgHome, pkgName), triple.Third)
 		if _, err := w.WriteString(fmt.Sprintf("cd \"%s\"\n%s\n%s\n", pkgHome, configCmd, buildCmd)); err != nil {
 			return err
 		}

--- a/pkg_yaml.go
+++ b/pkg_yaml.go
@@ -26,8 +26,9 @@ type YamlPackage V1Package
 
 type YamlGitPackage struct {
 	YamlPackage `yaml:",inline"`
-	Version     string `yaml:"version"`
-	Target      string `yaml:"target"`
+	Version     string   `yaml:"version"`
+	Target      string   `yaml:"target"`
+	Features    []string `yaml:"features"`
 }
 
 type YamlFilesPackage struct {

--- a/pkg_yaml.go
+++ b/pkg_yaml.go
@@ -1,7 +1,6 @@
 package pkg
 
 import (
-	"errors"
 	"fmt"
 	"runtime"
 )
@@ -67,14 +66,14 @@ type V1FilesPackage struct {
 }
 
 // find builder by os. If builder[os] is not found, return a fallback builder.
-func (yamlPkg *YamlPkg) FindBuilder() ([]string, error) {
+func (yamlPkg *YamlPkg) FindBuilder() []string {
 	if _build, ok := yamlPkg.Build[runtime.GOOS]; ok {
-		return _build[:], nil // builder can b empty if specified
+		return _build[:] // builder can be empty if specified
 	}
 	if _build, ok := yamlPkg.Build["fallback"]; ok {
-		return _build[:], nil // builder can b empty if specified
+		return _build[:] // builder can be empty if specified
 	}
-	return nil, errors.New("fallback builder is not specified")
+	return nil
 }
 
 func (v1 *V1Packages) MigrateToV2(d *YamlDependencies) error {

--- a/pkg_yaml.go
+++ b/pkg_yaml.go
@@ -1,7 +1,9 @@
 package pkg
 
 import (
+	"errors"
 	"fmt"
+	"runtime"
 )
 
 // for pkg yaml file parsing
@@ -62,6 +64,17 @@ type V1GitPackage struct {
 type V1FilesPackage struct {
 	V1Package `yaml:",inline"`
 	Files     map[string]string `yaml:"files"`
+}
+
+// find builder by os. If builder[os] is not found, return a fallback builder.
+func (yamlPkg *YamlPkg) FindBuilder() ([]string, error) {
+	if _build, ok := yamlPkg.Build[runtime.GOOS]; ok {
+		return _build[:], nil // builder can b empty if specified
+	}
+	if _build, ok := yamlPkg.Build["fallback"]; ok {
+		return _build[:], nil // builder can b empty if specified
+	}
+	return nil, errors.New("fallback builder is not specified")
 }
 
 func (v1 *V1Packages) MigrateToV2(d *YamlDependencies) error {


### PR DESCRIPTION
If `self_build `, `self_cmake_lib`, `builder ` and `cmake_lib` are all not specified, `AUTO_PKG` instruction will be used.

In `AUTO_PKG` instruction,  pkg will convert this  instruction  to CMAKE instruction by default.
But if environment variables `PKG_INNER_BUILD` is not empty, the package will be added into project source code for building (inner build).