### PR TITLE
Refactor install instruction

### DIFF
--- a/envs_test.go
+++ b/envs_test.go
@@ -8,7 +8,8 @@ import (
 
 func Test_ProcessEnv(t *testing.T) {
 	s := `1{{.CORES}}`
-	newstr := ProcessEnv(s)
+	envs := NewPackageEnvs("", "example", "vendor/src/example")
+	newstr, _ := ExpandEnv(s, envs)
 	ncpus := runtime.NumCPU()
 	if newstr != fmt.Sprintf("1%v", ncpus) {
 		t.Errorf("test failed.%s - %s", s, newstr)

--- a/pkg/install/build_pkg.go
+++ b/pkg/install/build_pkg.go
@@ -10,76 +10,39 @@ import (
 // pkgHome: the location of file pkg.yaml
 // skipDep: skip its dependency packages.
 func buildPkg(inst InsInterface, lists []string, metas map[string]pkg.PackageMeta, pkgHome string) error {
-	for _, item := range lists {
-		meta, ok := metas[item]
-		if !ok {
-			return fmt.Errorf("package %s not found", item)
-		}
-
-		pkg.AddVendorPathEnv(pkgHome) // use absolute path.
-		// add vars for this package, using relative path.
-		if err := pkg.AddPathEnv(item, meta.VendorSrcPath(pkgHome)); err != nil {
-			return err
-		}
-		// if outer build is specified, then inner build will be ignored.
-		if len(meta.Builder) == 0 {
-			// run inner build,(self build).
-			for _, ins := range meta.SelfBuild {
-				// replace vars in instruction with real value and run the instruction.
-				if err := RunIns(inst, &meta, pkg.ProcessEnv(ins)); err != nil {
-					return err
-				}
-			}
-		} else {
-			// run outer build.
-			for _, ins := range meta.Builder {
-				if err := RunIns(inst, &meta, pkg.ProcessEnv(ins)); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	return nil
-}
-
-func generateShell(inst InsInterface, lists []string, metas map[string]pkg.PackageMeta, pkgHome string) error {
 	if err := inst.Setup(); err != nil {
-		return err
+		return nil
 	}
-
 	for _, item := range lists {
 		meta, ok := metas[item]
 		if !ok {
 			return fmt.Errorf("package `%s` not found", item)
 		}
 
-		if err := inst.PkgPreInstall(&meta); err != nil {
+		packageEnv, err := inst.PkgPreInstall(&meta)
+		if err != nil {
 			return err
 		}
 
-		// using short path with env '$PKG_SRC_PATH'.
-		packageSrc := strings.Replace(meta.VendorSrcPath(pkgHome), pkg.GetPkgSrcPath(pkgHome), "$PKG_SRC_PATH", 1)
-		pkg.AddVendorPathEnv("$PROJECT_HOME") // use absolute path.
-		// add vars for this package
-		if err := pkg.AddPathEnv(item, packageSrc); err != nil {
-			return err
-		}
 		// if outer build is specified, then inner build will be ignored.
 		if len(meta.Builder) == 0 {
 			// run inner build,(self build).
 			for _, ins := range meta.SelfBuild {
-				// replace vars in instruction with real value and run the instruction.
-				if err := RunIns(inst, &meta, pkg.ProcessEnv(ins)); err != nil {
+				if err := RunIns(inst, &meta, packageEnv, ins); err != nil {
 					return err
 				}
 			}
 		} else {
 			// run outer build.
 			for _, ins := range meta.Builder {
-				if err := RunIns(inst, &meta, pkg.ProcessEnv(ins)); err != nil {
+				if err := RunIns(inst, &meta, packageEnv, ins); err != nil {
 					return err
 				}
+
 			}
+		}
+		if err := inst.PkgPostInstall(&meta); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/pkg/install/build_pkg.go
+++ b/pkg/install/build_pkg.go
@@ -3,7 +3,6 @@ package install
 import (
 	"fmt"
 	"github.com/genshen/pkg"
-	"os"
 	"strings"
 )
 
@@ -26,12 +25,6 @@ func buildPkg(inst InsInterface, lists []string, metas map[string]pkg.PackageMet
 		if len(meta.Builder) == 0 {
 			// run inner build,(self build).
 			for _, ins := range meta.SelfBuild {
-				// if it is auto pkg and outer build mode
-				if pkgEnvInc := os.Getenv("PKG_INNER_BUILD"); pkgEnvInc == "" && ins == pkg.InsAutoPkg {
-					// use cmake instruction with features (features as cmake options)
-					cmakeOpts := featuresToOptions(meta.Features)
-					ins = fmt.Sprintf(`%s "%s" "%s"`, pkg.InsCmake, cmakeOpts, "")
-				}
 				// replace vars in instruction with real value and run the instruction.
 				if err := RunIns(inst, &meta, pkg.ProcessEnv(ins)); err != nil {
 					return err
@@ -75,12 +68,6 @@ func generateShell(inst InsInterface, lists []string, metas map[string]pkg.Packa
 		if len(meta.Builder) == 0 {
 			// run inner build,(self build).
 			for _, ins := range meta.SelfBuild {
-				// if it is auto pkg and outer build mode
-				if pkgEnvInc := os.Getenv("PKG_INNER_BUILD"); pkgEnvInc == "" && ins == pkg.InsAutoPkg {
-					// use cmake instruction with features (features as cmake options)
-					cmakeOpts := featuresToOptions(meta.Features)
-					ins = fmt.Sprintf(`%s "%s" "%s"`, pkg.InsCmake, cmakeOpts, "")
-				}
 				// replace vars in instruction with real value and run the instruction.
 				if err := RunIns(inst, &meta, pkg.ProcessEnv(ins)); err != nil {
 					return err

--- a/pkg/install/build_pkg.go
+++ b/pkg/install/build_pkg.go
@@ -13,6 +13,8 @@ import (
 // pkgHome: the location of file pkg.yaml
 // skipDep: skip its dependency packages.
 func buildPkg(lists []string, metas map[string]pkg.PackageMeta, pkgHome string, verbose bool) error {
+	var insExe = NewInsExecutor(pkgHome, verbose)
+
 	for _, item := range lists {
 		log.WithFields(log.Fields{
 			"pkg": item,
@@ -36,14 +38,14 @@ func buildPkg(lists []string, metas map[string]pkg.PackageMeta, pkgHome string, 
 					ins = fmt.Sprintf(`%s "%s" "%s"`, pkg.InsCmake, cmakeOpts, "")
 				}
 				// replace vars in instruction with real value and run the instruction.
-				if err := RunIns(pkgHome, item, meta.VendorSrcPath(pkgHome), pkg.ProcessEnv(ins), verbose); err != nil {
+				if err := RunIns(&insExe, &meta, pkg.ProcessEnv(ins)); err != nil {
 					return err
 				}
 			}
 		} else {
 			// run outer build.
 			for _, ins := range meta.Builder {
-				if err := RunIns(pkgHome, item, meta.VendorSrcPath(pkgHome), pkg.ProcessEnv(ins), verbose); err != nil {
+				if err := RunIns(&insExe, &meta, pkg.ProcessEnv(ins)); err != nil {
 					return err
 				}
 			}
@@ -57,21 +59,11 @@ func buildPkg(lists []string, metas map[string]pkg.PackageMeta, pkgHome string, 
 }
 
 func generateShell(w *bufio.Writer, lists []string, metas map[string]pkg.PackageMeta, pkgHome string) error {
-	const shellHead = `#!/bin/sh
-set -e
-
-export PKG_VENDOR_PATH=%s
-PROJECT_HOME=%s
-PKG_SRC_PATH=%s
-`
-	var pkgSrcPath string
-	if sh, err := pkg.GetHomeSrcPath(); err != nil {
+	shWriter, err := NewInsShellWriter(pkgHome, w)
+	if err != nil {
 		return err
-	} else {
-		pkgSrcPath = sh
 	}
-
-	if _, err := w.WriteString(fmt.Sprintf(shellHead, pkg.GetVendorPath(pkgHome), pkgHome, pkgSrcPath)); err != nil {
+	if err := shWriter.Setup(); err != nil {
 		return err
 	}
 
@@ -86,7 +78,7 @@ PKG_SRC_PATH=%s
 		}
 
 		// using short path with env '$PKG_SRC_PATH'.
-		packageSrc := strings.Replace(meta.VendorSrcPath(pkgHome), pkgSrcPath, "$PKG_SRC_PATH", 1)
+		packageSrc := strings.Replace(meta.VendorSrcPath(pkgHome), pkg.GetPkgSrcPath(pkgHome), "$PKG_SRC_PATH", 1)
 		pkg.AddVendorPathEnv("$PROJECT_HOME") // use absolute path.
 		// add vars for this package
 		if err := pkg.AddPathEnv(item, packageSrc); err != nil {
@@ -103,15 +95,15 @@ PKG_SRC_PATH=%s
 					ins = fmt.Sprintf(`%s "%s" "%s"`, pkg.InsCmake, cmakeOpts, "")
 				}
 				// replace vars in instruction with real value and run the instruction.
-				if err := WriteIns(w, "$PROJECT_HOME", item, packageSrc, pkg.ProcessEnv(ins)); err != nil {
+				if err := RunIns(shWriter, &meta, pkg.ProcessEnv(ins)); err != nil {
 					return err
 				}
 			}
 		} else {
 			// run outer build.
 			for _, ins := range meta.Builder {
-				if err := WriteIns(w, "$PROJECT_HOME", item, packageSrc, pkg.ProcessEnv(ins)); err != nil {
-					return err
+				if err := RunIns(shWriter, &meta, pkg.ProcessEnv(ins)); err != nil {
+					return nil
 				}
 			}
 		}

--- a/pkg/install/command.go
+++ b/pkg/install/command.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 )
 
 // run the instruction
@@ -122,35 +121,6 @@ func (in *InsExecutor) InsAutoPkg(triple pkg.InsTriple, meta *pkg.PackageMeta) e
 		return in.InsCMake(triple, meta)
 	}
 	return nil
-}
-
-// run instruction.
-func RunIns(inst InsInterface, meta *pkg.PackageMeta, envs *pkg.PackageEnvs, ins string) error {
-	if expandedIns, err := pkg.ExpandEnv(ins, envs); err != nil {
-		return err
-	} else {
-		// parse instruction
-		triple, err := pkg.ParseIns(strings.Trim(expandedIns, " "))
-		if err != nil {
-			return err
-		}
-
-		switch triple.First {
-		case "CP":
-			if err := inst.InsCp(triple, meta); err != nil {
-				return err
-			}
-		case "RUN":
-			if err := inst.InsRun(triple, meta); err != nil {
-				return err
-			}
-		case pkg.InsCmake: // run cmake commands, format: CMAKE {config args} {build args}
-			if err := inst.InsCMake(triple, meta); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
 }
 
 func involveShell(pkgHome, workDir, script string, verbose bool) error {

--- a/pkg/install/command.go
+++ b/pkg/install/command.go
@@ -112,6 +112,14 @@ func (in *InsExecutor) InsCMake(triple pkg.InsTriple, meta *pkg.PackageMeta) err
 }
 
 func (in *InsExecutor) InsAutoPkg(triple pkg.InsTriple, meta *pkg.PackageMeta) error {
+	// if it is auto pkg and outer build mode
+	if pkgEnvInc := os.Getenv("PKG_INNER_BUILD"); pkgEnvInc == "" {
+		// use cmake instruction with features (features as cmake options)
+		triple.First = pkg.InsCmake
+		triple.Second = featuresToOptions(meta.Features)
+		triple.Third = ""
+		return in.InsCMake(triple, meta)
+	}
 	return nil
 }
 

--- a/pkg/install/command.go
+++ b/pkg/install/command.go
@@ -18,11 +18,26 @@ type InsExecutor struct {
 	verbose bool   // flag to show building logs when running a command
 }
 
-func NewInsExecutor(pkgHome string, verbose bool) InsExecutor {
-	return InsExecutor{pkgHome: pkgHome, verbose: verbose}
+func NewInsExecutor(pkgHome string, verbose bool) *InsExecutor {
+	return &InsExecutor{pkgHome: pkgHome, verbose: verbose}
 }
 
 func (in *InsExecutor) Setup() error {
+	return nil
+}
+
+func (in *InsExecutor) PkgPreInstall(meta *pkg.PackageMeta) error {
+	log.WithFields(log.Fields{
+		"pkg": meta.PackageName,
+	}).Info("installing package.")
+
+	return nil
+}
+
+func (in *InsExecutor) PkgPostInstall(meta *pkg.PackageMeta) error {
+	log.WithFields(log.Fields{
+		"pkg": meta.PackageName,
+	}).Info("package built and installed.")
 	return nil
 }
 

--- a/pkg/install/ins_interface.go
+++ b/pkg/install/ins_interface.go
@@ -6,6 +6,8 @@ import "github.com/genshen/pkg"
 type InsInterface interface {
 	// setup the building
 	Setup() error
+	PkgPreInstall(meta *pkg.PackageMeta) error
+	PkgPostInstall(meta *pkg.PackageMeta) error
 	// files copy
 	InsCp(triple pkg.InsTriple, meta *pkg.PackageMeta) error
 	// run a command

--- a/pkg/install/ins_interface.go
+++ b/pkg/install/ins_interface.go
@@ -6,7 +6,7 @@ import "github.com/genshen/pkg"
 type InsInterface interface {
 	// setup the building
 	Setup() error
-	PkgPreInstall(meta *pkg.PackageMeta) error
+	PkgPreInstall(meta *pkg.PackageMeta) (*pkg.PackageEnvs, error)
 	PkgPostInstall(meta *pkg.PackageMeta) error
 	// files copy
 	InsCp(triple pkg.InsTriple, meta *pkg.PackageMeta) error

--- a/pkg/install/ins_interface.go
+++ b/pkg/install/ins_interface.go
@@ -1,0 +1,16 @@
+package install
+
+import "github.com/genshen/pkg"
+
+// instruction interface
+type InsInterface interface {
+	// setup the building
+	Setup() error
+	// files copy
+	InsCp(triple pkg.InsTriple, meta *pkg.PackageMeta) error
+	// run a command
+	InsRun(triple pkg.InsTriple, meta *pkg.PackageMeta) error
+	// run cmake build
+	InsCMake(triple pkg.InsTriple, meta *pkg.PackageMeta) error
+	InsAutoPkg(triple pkg.InsTriple, meta *pkg.PackageMeta) error
+}

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -109,14 +109,19 @@ func (b *install) Run() error {
 		} else {
 			buffWriter := bufio.NewWriter(shellFile)
 			defer buffWriter.Flush()
-			if err := generateShell(buffWriter, options.lists, options.Metas, b.PkgHome); err != nil {
+			shWriter, err := NewInsShellWriter(b.PkgHome, buffWriter)
+			if err != nil {
+				return err
+			}
+			if err := generateShell(shWriter, options.lists, options.Metas, b.PkgHome); err != nil {
 				return err
 			}
 
 			log.Info("pkg building shell script generated at ", pkg.GetPkgBuildPath(b.PkgHome))
 		}
 	} else {
-		if err := buildPkg(options.lists, options.Metas, b.PkgHome, b.verbose); err != nil {
+		var insExe = NewInsExecutor(b.PkgHome, b.verbose)
+		if err := buildPkg(insExe, options.lists, options.Metas, b.PkgHome); err != nil {
 			return err
 		}
 		log.Info("all packages installed successfully.")

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -113,7 +113,7 @@ func (b *install) Run() error {
 			if err != nil {
 				return err
 			}
-			if err := generateShell(shWriter, options.lists, options.Metas, b.PkgHome); err != nil {
+			if err := buildPkg(shWriter, options.lists, options.Metas, b.PkgHome); err != nil {
 				return err
 			}
 

--- a/pkg/install/install_shell.go
+++ b/pkg/install/install_shell.go
@@ -7,6 +7,7 @@ import (
 	"github.com/genshen/pkg"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // writer instructions as shell format to file
@@ -39,11 +40,15 @@ PKG_SRC_PATH=%s
 	return nil
 }
 
-func (sh *InsShellWriter) PkgPreInstall(meta *pkg.PackageMeta) error {
+func (sh *InsShellWriter) PkgPreInstall(meta *pkg.PackageMeta) (*pkg.PackageEnvs, error) {
+	// using short path with env '$PKG_SRC_PATH'.
+	packageSrcPath := strings.Replace(meta.VendorSrcPath(sh.pkgHome), pkg.GetPkgSrcPath(sh.pkgHome), "$PKG_SRC_PATH", 1)
+	// package env
+	packageEnv := pkg.NewPackageEnvs("$PROJECT_HOME", meta.PackageName, packageSrcPath)
 	if _, err := sh.writer.WriteString(fmt.Sprintf("\n## pacakge %s\n", meta.PackageName)); err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return packageEnv, nil
 }
 
 func (sh *InsShellWriter) PkgPostInstall(meta *pkg.PackageMeta) error {

--- a/pkg/install/install_shell.go
+++ b/pkg/install/install_shell.go
@@ -38,6 +38,17 @@ PKG_SRC_PATH=%s
 	return nil
 }
 
+func (sh *InsShellWriter) PkgPreInstall(meta *pkg.PackageMeta) error {
+	if _, err := sh.writer.WriteString(fmt.Sprintf("\n## pacakge %s\n", meta.PackageName)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sh *InsShellWriter) PkgPostInstall(meta *pkg.PackageMeta) error {
+	return nil
+}
+
 func (sh *InsShellWriter) InsCp(triple pkg.InsTriple, meta *pkg.PackageMeta) error {
 	if triple.Second == "" || triple.Third == "" {
 		return errors.New("CP instruction must have src and des")

--- a/pkg/install/install_shell.go
+++ b/pkg/install/install_shell.go
@@ -1,0 +1,85 @@
+package install
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"github.com/genshen/pkg"
+	"path/filepath"
+)
+
+// writer instructions as shell format to file
+type InsShellWriter struct {
+	pkgHome string        // home directory of running pkg command
+	writer  *bufio.Writer // shell script file writer
+}
+
+func NewInsShellWriter(pkgHome string, w *bufio.Writer, ) (*InsShellWriter, error) {
+	return &InsShellWriter{
+		pkgHome: pkgHome,
+		writer:  w,
+	}, nil
+}
+
+func (sh *InsShellWriter) Setup() error {
+	const shellHead = `#!/bin/sh
+set -e
+
+export PKG_VENDOR_PATH=%s
+PROJECT_HOME=%s
+PKG_SRC_PATH=%s
+`
+
+	pkgSrcPath := pkg.GetPkgSrcPath(sh.pkgHome)
+	if _, err := sh.writer.WriteString(fmt.Sprintf(shellHead, pkg.GetVendorPath(sh.pkgHome), sh.pkgHome, pkgSrcPath)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (sh *InsShellWriter) InsCp(triple pkg.InsTriple, meta *pkg.PackageMeta) error {
+	if triple.Second == "" || triple.Third == "" {
+		return errors.New("CP instruction must have src and des")
+	}
+
+	srcPath := meta.VendorSrcPath(sh.pkgHome) // todo: use shell variable as prefix
+	if _, err := sh.writer.WriteString(fmt.Sprintf("mkdir -p \"%s\"\n", pkg.GetIncludePath(sh.pkgHome))); err != nil {
+		return err
+	}
+	if _, err := sh.writer.WriteString(fmt.Sprintf("cp -r \"%s\" \"%s\"\n",
+		filepath.Join(srcPath, triple.Second), triple.Third)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sh *InsShellWriter) InsRun(triple pkg.InsTriple, meta *pkg.PackageMeta) error {
+	if triple.Second == "" || triple.Third == "" {
+		return errors.New("RUN instruction must be a triple")
+	}
+
+	if _, err := sh.writer.WriteString(fmt.Sprintf("mkdir -p \"%s\"\ncd \"%s\"\n%s\n",
+		triple.Second, triple.Second, triple.Third)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sh *InsShellWriter) InsCMake(triple pkg.InsTriple, meta *pkg.PackageMeta) error {
+	srcPath := meta.VendorSrcPath(sh.pkgHome) // todo: use shell variable as prefix
+
+	var configCmd = fmt.Sprintf("cmake -S \"%s\" -B \"%s\" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=\"%s\" %s",
+		srcPath, pkg.GetCachePath(sh.pkgHome, meta.PackageName),
+		pkg.GetPackagePkgPath(sh.pkgHome, meta.PackageName), triple.Second)
+	var buildCmd = fmt.Sprintf("cmake --build \"%s\" --target install %s",
+		pkg.GetCachePath(sh.pkgHome, meta.PackageName), triple.Third)
+	if _, err := sh.writer.WriteString(fmt.Sprintf("cd \"%s\"\n%s\n%s\n", sh.pkgHome, configCmd, buildCmd)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sh *InsShellWriter) InsAutoPkg(triple pkg.InsTriple, meta *pkg.PackageMeta) error {
+	return nil
+}

--- a/pkg/install/install_shell.go
+++ b/pkg/install/install_shell.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/genshen/pkg"
+	"os"
 	"path/filepath"
 )
 
@@ -92,5 +93,14 @@ func (sh *InsShellWriter) InsCMake(triple pkg.InsTriple, meta *pkg.PackageMeta) 
 }
 
 func (sh *InsShellWriter) InsAutoPkg(triple pkg.InsTriple, meta *pkg.PackageMeta) error {
+	// if it is auto pkg and outer build mode
+	// todo only for inner builders
+	if pkgEnvInc := os.Getenv("PKG_INNER_BUILD"); pkgEnvInc == "" {
+		// use cmake instruction with features (features as cmake options)
+		triple.First = pkg.InsCmake
+		triple.Second = featuresToOptions(meta.Features)
+		triple.Third = ""
+		return sh.InsCMake(triple, meta)
+	}
 	return nil
 }


### PR DESCRIPTION
- combine install executor and shell script generation by a common interface.
- refactor instruction env expanding: use local struct instead of global map.