### PR TITLE
feat(fetch): add option `NO_DEFAULT_PATH` for find_package when generating file pkg.dep.cmake

### DIFF
--- a/pkg/fetch/cmake_lib.go
+++ b/pkg/fetch/cmake_lib.go
@@ -55,7 +55,7 @@ const (
 #     outer build command: <<.OuterBuildCommand>>
 <<if eq .SelfCMakeLib "AUTO_PKG">>
 if(NOT ${<<.TargetName>>_FOUND} OR ${<<.TargetName>>_FOUND} STREQUAL "")
-	find_package(<<.TargetName>> PATHS <<.PkgDir>>)
+	find_package(<<.TargetName>> PATHS <<.PkgDir>> NO_DEFAULT_PATH)
 endif()
 <<else>>
 	<<.SelfCMakeLib>> # inner cmake

--- a/pkg/fetch/cmake_lib.go
+++ b/pkg/fetch/cmake_lib.go
@@ -15,11 +15,12 @@ import (
 
 type cmakeDepData struct {
 	pkg.PackageMeta
-	SrcDir            string
-	PkgDir            string
-	DepsDir           string // cmake binary dir if it is added by add_subdirectory
-	InnerBuildCommand []string
-	OuterBuildCommand []string
+	SrcDir             string
+	PkgDir             string
+	DepsDir            string // cmake binary dir if it is added by add_subdirectory
+	FindPackageOptions string // options for finding package in `find_package(foo PATH ..)`
+	InnerBuildCommand  []string
+	OuterBuildCommand  []string
 }
 
 type cmakeDepHeaderData struct {
@@ -55,7 +56,7 @@ const (
 #     outer build command: <<.OuterBuildCommand>>
 <<if eq .SelfCMakeLib "AUTO_PKG">>
 if(NOT ${<<.TargetName>>_FOUND} OR ${<<.TargetName>>_FOUND} STREQUAL "")
-	find_package(<<.TargetName>> PATHS <<.PkgDir>> NO_DEFAULT_PATH)
+	find_package(<<.TargetName>> PATHS <<.PkgDir>> <<.FindPackageOptions>>)
 endif()
 <<else>>
 	<<.SelfCMakeLib>> # inner cmake
@@ -87,7 +88,7 @@ endif()
 
 // pkgHome is always pkg root.
 // write cmake script for all direct and indirect dependencies packages.
-func createPkgDepCmake(pkgHome string, rootDep *pkg.DependencyTree) error {
+func createPkgDepCmake(pkgHome string, rootDep *pkg.DependencyTree, findPackageOptions string) error {
 	depsList, err := rootDep.ListDeps(false)
 	if err != nil {
 		return err
@@ -115,7 +116,7 @@ func createPkgDepCmake(pkgHome string, rootDep *pkg.DependencyTree) error {
 
 				// compute and render body template.
 				// (write cmake include and find_package script of all dependency packages)
-				if err := cmakeLib(depTree, pkgHome, bufWriter); err != nil {
+				if err := cmakeLib(depTree, pkgHome, findPackageOptions, bufWriter); err != nil {
 					return err
 				}
 				if err := bufWriter.Flush(); err != nil {
@@ -144,7 +145,7 @@ func createPkgDepCmake(pkgHome string, rootDep *pkg.DependencyTree) error {
 // generate/render cmake script of a package specified by depTree.
 //the result comes from its dependencies,
 // pkgHome: absolute path for pkg home.
-func cmakeLib(depTree *pkg.DependencyTree, pkgHome string, writer io.Writer) error {
+func cmakeLib(depTree *pkg.DependencyTree, pkgHome string, findPackageOptions string, writer io.Writer) error {
 	// skip master package by setting parameter skipRoota as true,
 	// do not generate cmake include and find_package script for the master package itself lib.
 	depsList, err := depTree.ListDeps(true) // list all dependencies
@@ -167,9 +168,10 @@ func cmakeLib(depTree *pkg.DependencyTree, pkgHome string, writer io.Writer) err
 				CMakeLib:     dep.Context.CMakeLib,
 				Features:     dep.Context.Features,
 			},
-			SrcDir:  src,
-			DepsDir: pkg.GetPackageDepsPath(basePath, dep.Context.PackageName),
-			PkgDir:  pkg.GetPackagePkgPath(basePath, dep.Context.PackageName),
+			SrcDir:             src,
+			DepsDir:            pkg.GetPackageDepsPath(basePath, dep.Context.PackageName),
+			PkgDir:             pkg.GetPackagePkgPath(basePath, dep.Context.PackageName),
+			FindPackageOptions: findPackageOptions,
 		}
 		// copy slice, don't modify the original data.
 		toFile.OuterBuildCommand = make([]string, len(dep.Context.Builder))

--- a/pkg/fetch/fetch.go
+++ b/pkg/fetch/fetch.go
@@ -39,6 +39,7 @@ func init() {
 	fetchCommand.FlagSet = fs
 	//fetchCommand.FlagSet.BoolVar(&absRoot, "abspath", false, "use absolute path, not relative path")
 	fetchCommand.FlagSet.StringVar(&f.PkgHome, "p", pwd, "absolute or relative path for file "+pkg.PkgFileName)
+	fetchCommand.FlagSet.StringVar(&f.CMakeFindPackageOption, "cmake-find-package-arg", "NO_DEFAULT_PATH", "global options for find_package when generating file pkg.dep.cmake")
 	// todo make pkgHome abs path anyway.
 	fetchCommand.FlagSet.Usage = fetchCommand.Usage // use default usage provided by cmds.Command.
 	fetchCommand.Runner = &f
@@ -46,10 +47,12 @@ func init() {
 }
 
 type fetch struct {
-	PkgHome       string // the absolute path of root 'pkg.yaml' form command path.
-	DepTree       pkg.DependencyTree
-	Auth          map[string]conf.Auth
-	GlobalReplace map[string]string
+	PkgHome                string // the absolute path of root 'pkg.yaml' form command path.
+	CMakeFindPackageOption string // global find_package option, default is "NO_DEFAULT_PATH".
+	MirrorConfPath         string // the file path of repo mirror file.
+	DepTree                pkg.DependencyTree
+	Auth                   map[string]conf.Auth
+	GlobalReplace          map[string]string
 }
 
 func (f *fetch) PreRun() error {
@@ -167,7 +170,7 @@ func (f *fetch) Run() error {
 	// generating cmake script to include dependency libs.
 	// the generated cmake file is stored at where pkg command runs.
 	// for project package, its srcHome equals to PkgHome.
-	if err := createPkgDepCmake(f.PkgHome, &f.DepTree); err != nil {
+	if err := createPkgDepCmake(f.PkgHome, &f.DepTree, f.CMakeFindPackageOption); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
If `NO_DEFAULT_PATH` option is not added, cmake may search paths out of the project directories, which may find a wrong lib version for linking. By adding this option to `find_package`, we can tell cmake to search lib in project's `vendor` directory to avoid the above issue.