### PR TITLE
ci(github-action): bump action upload-artifact, download-artifact to v4 and action-gh-release to v2

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Build
         run: make
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: build-artifact
           path: pkg-*
@@ -36,13 +36,13 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
         with:
           name: build-artifact
 #      - run: ls -R
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |


### PR DESCRIPTION

Note: v1 and v2 of the artifact actions is deprecated in 2024/03. We must use the new version of artifact actions.
