### PR TITLE
Fix pkg export: fix the nil go context passed to `archives.FilesFromDisk` for exporting package archive

### DIFF
--- a/pkg/export/export.go
+++ b/pkg/export/export.go
@@ -83,7 +83,7 @@ func (e *export) Run() error {
 		Archival:    archives.Tar{},
 	}
 
-	tarFiles, err := archives.FilesFromDisk(nil, &archives.FromDiskOptions{}, map[string]string{
+	tarFiles, err := archives.FilesFromDisk(context.Background(), &archives.FromDiskOptions{}, map[string]string{
 		pkg.GetPkgSumPath(e.home):   strings.TrimPrefix(pkg.GetPkgSumPath(""), pkg.VendorName),
 		pkg.GetDepGraphPath(e.home): strings.TrimPrefix(pkg.GetDepGraphPath(""), pkg.VendorName),
 		pkg.GetPkgSrcPath(e.home):   strings.TrimPrefix(pkg.GetPkgSrcPath(""), pkg.VendorName),


### PR DESCRIPTION
When using the new version package `github.com/mholt/archives` to generate archive, it requires a parameter as context. We pass nil as context, which can cause panic when exec `pkg export`. We now fix it by passing `context.Background()` as the context.

related commit for this bug: a0d398e
related PR for this bug: #22