### PR TITLE
fix(install): fix incorrect trim of quotation mark in install instruction

### DIFF
--- a/ins_parser.go
+++ b/ins_parser.go
@@ -53,7 +53,11 @@ func ParseIns(insStr string) (ins InsTriple, err error) {
 	}
 
 	// parse third
-	ins.Third = strings.Trim(ins.Third, `"`)
 	ins.Third = strings.TrimSpace(ins.Third)
+	if strings.HasPrefix(ins.Third, `"`) && strings.HasSuffix(ins.Third, `"`) {
+		// it does not process instructions like `echo "hello"`
+		ins.Third = strings.Trim(ins.Third, `"`)
+	}
+
 	return ins, err
 }


### PR DESCRIPTION
Only both the leading and the trailing quotation mark exit, we can perform trim. Before this commit, for the instruction `echo "hello"`, the trailing quotation mark will be removed, which can produce `echo "hello` (it is a wrong result). This commit fixes the bug.
