### PR TITLE
fix(version): keep format version checking backward compatibility to version 1

### DIFF
--- a/pkg/fetch/fetch.go
+++ b/pkg/fetch/fetch.go
@@ -258,8 +258,8 @@ func (f *fetch) fetchSubDependency(pkgPath string, pkgVendorSrcPath string, acti
 				}
 			}
 
-			if pkgYaml.FormatVersion != pkg.FORMAT_VERSION {
-				return fmt.Errorf("package format version does not match, require format version is %d", pkg.FORMAT_VERSION)
+			if pkgYaml.FormatVersion < pkg.COMPATIBLE_MIN_FORMAT_VERSION {
+				return fmt.Errorf("package format version does not match, require min format version is %d", pkg.COMPATIBLE_MIN_FORMAT_VERSION)
 			}
 
 			// process features: filter active features and get the optional packages for the features.

--- a/version.go
+++ b/version.go
@@ -2,3 +2,4 @@ package pkg
 
 const VERSION = "v0.6.0"
 const FORMAT_VERSION = 3
+const COMPATIBLE_MIN_FORMAT_VERSION = 1


### PR DESCRIPTION
Before this commit, due to the bug of format version checking, it can only be compatible with version 3, cannot be compatible with version 1 and 2.