### PR TITLE
Fix tarball extraction error "no extraction format" in fetch and import subcommand

### DIFF
--- a/pkg/fetch/src_dl.go
+++ b/pkg/fetch/src_dl.go
@@ -168,15 +168,16 @@ func archiveSrc(archiveType string, srcPath string, packageName string, remoteUr
 	} else {
 		defer f.Close()
 
+		// todo use archives.Identify(), instead of if-else.
 		ac := archives.CompressedArchive{}
 		if archiveType == "tar.bz2" {
+			ac.Extraction = archives.Tar{}
 			ac.Compression = archives.Bz2{}
-			ac.Archival = archives.Tar{}
 		} else if archiveType == "tar.gz" {
+			ac.Extraction = archives.Tar{}
 			ac.Compression = archives.Gz{}
-			ac.Archival = archives.Tar{}
 		} else if archiveType == "zip" {
-			ac.Archival = archives.Zip{}
+			ac.Extraction = archives.Zip{}
 		} else {
 			return errors.New("unsupported type error")
 		}

--- a/pkg/import/import.go
+++ b/pkg/import/import.go
@@ -90,7 +90,7 @@ func (i *_import) Run() error {
 
 	format := archives.CompressedArchive{
 		Compression: archives.Gz{},
-		Archival:    archives.Tar{},
+		Extraction:  archives.Tar{},
 	}
 
 	handle := func(ctx context.Context, f archives.FileInfo) error {


### PR DESCRIPTION
- fix the error in fetch subcommand when fetching and extracting a package of archive type;
- fix the error in import subcommand when importing a tarball file.